### PR TITLE
Don't reexport `Reflection.Syntax` from `Tactic.Inline`

### DIFF
--- a/Tactic/Inline.agda
+++ b/Tactic/Inline.agda
@@ -18,7 +18,7 @@ open import Class.MonadTC.Instances
 open import Class.MonadError.Instances
 
 open import Meta.Prelude
-open import Reflection.Syntax public
+open import Reflection.Syntax
 open import Reflection.Utils using (apply∗)
 open import Reflection.Utils.Debug; open Debug ("tactic.inline" , 100)
 -- open import Meta.Init


### PR DESCRIPTION
In particular, this reexported `Type`, which you don't want if you've renamed `Set` to `Type`.