### PR TITLE
Make some auxiliary definitions private

### DIFF
--- a/Tactic/Inline.agda
+++ b/Tactic/Inline.agda
@@ -23,11 +23,12 @@ open import Reflection.Utils using (apply∗)
 open import Reflection.Utils.Debug; open Debug ("tactic.inline" , 100)
 -- open import Meta.Init
 open import Reflection using (TC)
-instance
-  iTC  = MonadTC-TC
-  iTCE = MonadError-TC
 
 private
+  instance
+    iTC  = MonadTC-TC
+    iTCE = MonadError-TC
+
   pattern `case_of_ x y = quote case_of_ ∙⟦ x ∣ y ⟧
 
   $inline : Bool → Name → Term → TC ⊤


### PR DESCRIPTION
I got some clashes here and there with private? instances and auxiliary functions being exported.