### PR TITLE
Improve performance of `DecEq` deriving

### DIFF
--- a/Reflection/QuotedDefinitions.agda
+++ b/Reflection/QuotedDefinitions.agda
@@ -1,0 +1,31 @@
+{-# OPTIONS --safe --without-K #-}
+
+module Reflection.QuotedDefinitions where
+
+open import Meta.Prelude
+
+open import Reflection.Syntax
+
+infix 4 _`≡_ _``≡_
+_`≡_ : Term → Term → Term
+t `≡ t' = quote _≡_ ∙⟦ t ∣ t' ⟧
+
+pattern _``≡_ t t' = def (quote _≡_) (_ ∷ _ ∷ vArg t ∷ vArg t' ∷ [])
+
+`refl : Term
+`refl = quote refl ◆
+
+pattern ``refl = quote refl ◇
+
+`case_of_ : Term → Term → Term
+`case t of t' = quote case_of_ ∙⟦ t ∣ t' ⟧
+
+-- Syntax for quoting `yes` and `no`
+open import Relation.Nullary
+
+`yes `no : Term → Term
+`yes x = quote _because_ ◆⟦ quote true  ◆ ∣ quote ofʸ ◆⟦ x ⟧ ⟧
+`no  x = quote _because_ ◆⟦ quote false ◆ ∣ quote ofⁿ ◆⟦ x ⟧ ⟧
+
+pattern ``yes x = quote _because_ ◇⟦ quote true  ◇ ∣ quote ofʸ ◇⟦ x ⟧ ⟧
+pattern ``no x  = quote _because_ ◇⟦ quote false ◇ ∣ quote ofⁿ ◇⟦ x ⟧ ⟧

--- a/Reflection/Syntax.agda
+++ b/Reflection/Syntax.agda
@@ -111,11 +111,3 @@ Context      = Args Type
 TTerm        = Term × Type
 Hole         = Term
 THole        = Hole × Type
-
--- Syntax for quoting `yes` and `no`
-open import Relation.Nullary
-open import Relation.Nullary.Decidable
-
-`yes `no : Term → Term
-`yes x = quote _because_ ◆⟦ quote true  ◆ ∣ quote ofʸ ◆⟦ x ⟧ ⟧
-`no  x = quote _because_ ◆⟦ quote false ◆ ∣ quote ofⁿ ◆⟦ x ⟧ ⟧

--- a/Reflection/Syntax.agda
+++ b/Reflection/Syntax.agda
@@ -111,3 +111,11 @@ Context      = Args Type
 TTerm        = Term × Type
 Hole         = Term
 THole        = Hole × Type
+
+-- Syntax for quoting `yes` and `no`
+open import Relation.Nullary
+open import Relation.Nullary.Decidable
+
+`yes `no : Term → Term
+`yes x = quote _because_ ◆⟦ quote true  ◆ ∣ quote ofʸ ◆⟦ x ⟧ ⟧
+`no  x = quote _because_ ◆⟦ quote false ◆ ∣ quote ofⁿ ◆⟦ x ⟧ ⟧

--- a/Tactic/Derive/TestTypes.agda
+++ b/Tactic/Derive/TestTypes.agda
@@ -42,6 +42,9 @@ record R2 {a} (A : Set a) : Set a where
         f5R2 : A
         f6R2 : A
 
+record R20 : Set where
+  field r0 r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 r12 r13 r14 r15 r16 r17 r18 r19 : Bool
+
 data M₁ : Set
 data M₂ : Set
 data M₁ where


### PR DESCRIPTION
I see ~47% speedup in instance generation time (typechecking) and ~22% speedup at runtime (normalization) with admittedly flaky benchmarks. Crucially, the generated instances should now only ever force booleans during normalization if all we want to know is the boolean equality.

Since this is probably the single most used feature provided by this library, I invite everyone to test if all instances still generate correctly and that there are no performance regressions.

(Also, I realized just now that apparently #33 got merged before I did my improvements to it, so the commits are now in this PR. I don't mind having them tangled so I'll keep it like that for now, but I'll put them in a separate PR if desired).