### PR TITLE
Tactic.Derive: avoid pair-level decidable equality in genMutualHelpers (fixes deriving OOM)

### DIFF
--- a/Tactic/Derive.agda
+++ b/Tactic/Derive.agda
@@ -45,7 +45,6 @@ instance
   _ = ContextMonad-MonadTC
   _ = Functor-M {M = TC}
   _ = Show-List
-  _ = DecEq-×
 
 open ClauseExprM
 
@@ -159,11 +158,24 @@ open AllChainsTo using (allChainsTo)
 -- Collect all non-empty wrapper chains (tagged with their terminating
 -- seed) discovered in the constructors arguments of the constructors
 -- of any seed.
+-- Boolean equality on chain entries. Deliberately NOT the decidable
+-- `_≟_` on pairs: `≡-dec` on Σ-types matches on the equality proof of
+-- the first component, and normalising equality proofs between
+-- reflection `Name`s goes through `Word64`/`ℕ` proofs whose normal
+-- forms are astronomically large, blowing up the type checker.
+eqChainEntry : WrapperChain × Name → WrapperChain × Name → Bool
+eqChainEntry (c , t) (c' , t') = eqChain c c' ∧ (t ≡ᵇ t')
+  where
+    eqChain : WrapperChain → WrapperChain → Bool
+    eqChain []       []         = true
+    eqChain (n ∷ ns) (n' ∷ ns') = (n ≡ᵇ n') ∧ eqChain ns ns'
+    eqChain _        _          = false
+
 genMutualHelpers : List Name → TC (List (WrapperChain × Name))
 genMutualHelpers ns = do
   tysPerSeed ← traverse
     (λ n → L.map (unArg ∘ unAbs) <$> (L.concatMap (proj₁ ∘ viewTy ∘ proj₂) <$> getConstrs n)) ns
-  return $ deduplicate _≟_ $ L.concatMap (allChainsTo ns) $ concat tysPerSeed
+  return $ L.deduplicateᵇ eqChainEntry $ L.concatMap (allChainsTo ns) $ concat tysPerSeed
 
 module _ (arity : ℕ) (genCe : (Term → Maybe Name) → List SinglePattern → List (NE.List⁺ SinglePattern × TC (ClauseExpr ⊎ Maybe Term))) where
   -- Generate the declaration & definition of a particular derivation.

--- a/Tactic/Derive/DecEq.agda
+++ b/Tactic/Derive/DecEq.agda
@@ -153,4 +153,6 @@ private
 
   unquoteDecl DecEq-N₁ DecEq-N₂ = derive-DecEq $ (quote N₁ , DecEq-N₁) ∷ (quote N₂ , DecEq-N₂) ∷ []
 
+  unquoteDecl DecEq-N₃ = derive-DecEq [ (quote N₃ , DecEq-N₃) ]
+
   -- Expected: DecEq-Term DecEq-Product

--- a/Tactic/Derive/TestTypes.agda
+++ b/Tactic/Derive/TestTypes.agda
@@ -71,6 +71,14 @@ data N₂ where
   n₂  : N₂
   n₁→₂ : N₁ → N₂
 
+-- Two constructors with the same wrapper chain (`List N₃`).
+-- Deduplicating the discovered chains must not evaluate a pair-level
+-- decidable equality: its proof normalisation explodes on reflection
+-- names. Guards the Boolean dedup in `genMutualHelpers`.
+data N₃ : Set where
+  n₃ˡ : List N₃ → N₃
+  n₃ʳ : List N₃ → N₃
+
 AllTestTypes : List Name
 AllTestTypes = quote E0 ∷ quote E1 ∷ quote E2 ∷ quote E3 ∷ quote R1 ∷ quote R2 ∷ quote M₁ ∷ quote M₂ ∷ quote E5 ∷ []
 


### PR DESCRIPTION
# Fix OOM in `genMutualHelpers` chain deduplication

## Problem

Since 27a1d37 ("Improve deriving support for nested types"), deriving a class for a datatype that has **two or more constructor fields with the same wrapper chain** makes the type checker allocate tens of GB and get OOM-killed. Minimal reproduction against current master (5690f32):

```agda
{-# OPTIONS --safe #-}
module T5 where
open import Data.List using (List; []; _∷_)
open import Data.Product using (_,_)
open import Class.DecEq
open import Tactic.Defaults
open import Tactic.Derive.DecEq

data T : Set where
  allOf : List T → T
  anyOf : List T → T

unquoteDecl DecEq-T = derive-DecEq ((quote T , DecEq-T) ∷ [])
```

Checking this module peaks above **41 GB** (observed OOM-killed at 41.9 GB on a 62 GB machine; with either constructor removed it checks in ~10 s at 1.1 GB).

We hit this in the wild via the Cardano ledger's `Timelock` type — three constructors carrying `List Timelock` fields — in IntersectMBO/formal-ledger-specifications#1286, where CI was OOM-killed on both x86_64-linux and aarch64-darwin, deterministically at that module.

Runnable copies of this MWE and two further-distilled ones (a single `(List Name × Name)` comparison; a pure-stdlib `ℕ × ℕ` version of the mechanism) are in this gist: https://gist.github.com/williamdemeo/8395f616a945ca641f52eb1cef90c7c6


## Cause

`genMutualHelpers` deduplicates the discovered wrapper chains with a decidable equality on pairs:

```agda
return $ deduplicate _≟_ $ L.concatMap (allChainsTo ns) $ concat tysPerSeed
-- _≟_ at type DecEq (WrapperChain × Name), via the local `instance _ = DecEq-×`
```

With two fields sharing a chain the list contains two equal `(WrapperChain × Name)` entries, so `deduplicate` performs its first real comparison. That comparison goes through `DecEq-×` = `Data.Product.Properties.≡-dec`, which is defined by

```agda
≡-dec dec₁ dec₂ (a , x) (b , y) with dec₁ a b
... | no [a≢b] = …
... | yes refl = …
```

Matching `yes refl` **forces full normalisation of the first component's equality proof**. An equality proof between reflection `Name`s normalises through `toWords`/`toℕ` into `Data.Nat` proofs (`≡ᵇ⇒≡`) whose normal forms are `cong suc`-towers **proportional to the numeric value** of the name's `Word64` components — 64-bit hash values for the module-name word. Hence a single comparison allocates essentially without bound.

The mechanism reproduces in pure stdlib, no reflection involved:

```agda
instance _ = DecEq-×

big : ℕ
big = 1152921504606846976  -- 2^60

_ : (if ⌊ (big , big) ≟ (big , big) ⌋ then "EQ" else "NE") ≡ "EQ"
_ = refl   -- >40 GB, OOM
```

while bare `⌊ big ≟ big ⌋` is instant: every other decider on the path (`map′`, `_×-dec_`, `Data.List.Properties.≡-dec`) is proof-lazy (copattern style — `⌊_⌋` only ever computes `does`); the Σ `≡-dec` is the one strict spot.

That is also why the existing nested test types (`E3`/`E5`/`N₁`/`N₂` — at most one field per chain, so `deduplicate` never actually compares) didn't catch it.

## Fix

Deduplicate with a Boolean comparison instead — `deduplicateᵇ` over `Name`-level `_≡ᵇ_`, which only computes `does` and never touches proofs — and drop the `instance _ = DecEq-×` alias, whose only purpose was this call. Same spirit as the existing remark in `Reflection.Utils.Core` ("Deliberately *not* `Class.DecEq`'s `_==_`: this sits on solver hot paths…").

Adds `N₃` (two constructors sharing the chain `List N₃`) to the test types, with a `derive-DecEq` regression test in `Tactic.Derive.DecEq`; without the fix that test OOMs.

## Validation

| check | master (5690f32) | with this PR |
|---|---|---|
| repro above (`T5`) | OOM, ≥ 41 GB | passes in seconds, ~1.1 GB |
| `Tactic.Derive.DecEq` self-tests (E3/E5/M₁-M₂/N₁-N₂ + new N₃) | — | pass |
| whole-library root module `standard-library-meta.agda` | — | passes (1:41, 4.8 GB peak) |
| formal-ledger `Timelock` module (the CI kill site) | OOM on 16 GB CI runners | 3.0 GB peak, passes |
| full formal-ledger-specifications build (`src/Ledger.lagda.md`, 276 modules) | OOM at `Timelock` | exit 0, 33 min, 10.2 GB peak |

A proof-lazy pair decider upstream (in `Data.Product.Properties` or stdlib-classes' `DecEq-×`) would remove the trap at the source; happy to file that separately — this PR just keeps the deriving machinery off the strict path.
